### PR TITLE
Fix SharpZipLib namespace reference

### DIFF
--- a/RagnaPH Launcher.Tests/ThorArchiveTests.cs
+++ b/RagnaPH Launcher.Tests/ThorArchiveTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
-using ICSharpCode.SharpZipLib.Checksums;
+using ICSharpCode.SharpZipLib.Checksum;
 using RagnaPH.Patching;
 using Xunit;
 

--- a/RagnaPH Launcher/Patching/ThorArchive.cs
+++ b/RagnaPH Launcher/Patching/ThorArchive.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip.Compression;
 using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
-using ICSharpCode.SharpZipLib.Checksums;
+using ICSharpCode.SharpZipLib.Checksum;
 using ICSharpCode.SharpZipLib;
 
 namespace RagnaPH.Patching;


### PR DESCRIPTION
## Summary
- use SharpZipLib Checksum namespace instead of deprecated Checksums
- update ThorArchive tests to match new namespace

## Testing
- `dotnet test 'RagnaPH Launcher.Tests/RagnaPH Launcher.Tests.csproj'` *(fails: Program does not contain a static 'Main' method suitable for an entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cb331e1c832eb07a86eaf5f81cce