### PR TITLE
Ensure SharpZipLib is copied with launcher

### DIFF
--- a/RagnaPH Launcher/App.config
+++ b/RagnaPH Launcher/App.config
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup> 
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+    <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/RagnaPH Launcher/RagnaPH Launcher.csproj
+++ b/RagnaPH Launcher/RagnaPH Launcher.csproj
@@ -17,6 +17,7 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -169,6 +170,7 @@
     <!-- Explicit reference to SharpZipLib to ensure availability during cross-platform builds -->
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>$(NuGetPackageRoot)sharpziplib/1.4.2/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>true</Private>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
## Summary
- force SharpZipLib to copy locally so the launcher can load it at runtime
- add binding redirect for SharpZipLib so the correct assembly version is used

## Testing
- `dotnet test "RagnaPH Launcher.Tests/RagnaPH Launcher.Tests.csproj"` *(fails: Program does not contain a static 'Main' method suitable for an entry point)*
- `dotnet msbuild "RagnaPH Launcher/RagnaPH Launcher.csproj" -p:Configuration=Release` *(fails: Program does not contain a static 'Main' method suitable for an entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cd039620832eb3efb912a7c6bfbd