### PR TITLE
Ensure SharpZipLib assembly ships with launcher

### DIFF
--- a/RagnaPH Launcher/App.config
+++ b/RagnaPH Launcher/App.config
@@ -2,6 +2,7 @@
 <configuration>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!-- Redirect SharpZipLib to ensure correct version is loaded -->
             <dependentAssembly>
                 <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />

--- a/RagnaPH Launcher/RagnaPH Launcher.csproj
+++ b/RagnaPH Launcher/RagnaPH Launcher.csproj
@@ -170,7 +170,8 @@
     <!-- Explicit reference to SharpZipLib to ensure availability during cross-platform builds -->
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>$(NuGetPackageRoot)sharpziplib/1.4.2/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>true</Private>
+      <Private>True</Private>
+      <CopyLocal>True</CopyLocal>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
## Summary
- force ICSharpCode.SharpZipLib.dll to copy locally so it is bundled next to RagnaPH.exe
- document bindingRedirect for SharpZipLib in App.config to avoid load errors

## Testing
- `dotnet test` *(fails: Program does not contain a static 'Main' method / WPF build errors)*
- `dotnet build 'RagnaPH Launcher/RagnaPH Launcher.csproj' -c Release` *(fails: Program does not contain a static 'Main' method / InitializeComponent not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cf642b28832ea48729b44a16f90e