### PR TITLE
Embed SharpZipLib to prevent missing DLL

### DIFF
--- a/RagnaPH Launcher/App.config
+++ b/RagnaPH Launcher/App.config
@@ -5,7 +5,7 @@
             <!-- Redirect SharpZipLib to ensure correct version is loaded -->
             <dependentAssembly>
                 <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
+                <bindingRedirect oldVersion="0.0.0.0-9.9.9.9" newVersion="1.4.2.13" />
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/RagnaPH Launcher/App.xaml.cs
+++ b/RagnaPH Launcher/App.xaml.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
+using System.IO;
+using System.Reflection;
 using System.Windows;
 
 namespace RagnaPH_Launcher
@@ -13,5 +10,23 @@ namespace RagnaPH_Launcher
     /// </summary>
     public partial class App : Application
     {
+        static App()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += (s, e) =>
+            {
+                var name = new AssemblyName(e.Name).Name;
+                if (!name.Equals("ICSharpCode.SharpZipLib", StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                using var stream = Assembly.GetExecutingAssembly()
+                    .GetManifestResourceStream("RagnaPH.Libs.ICSharpCode.SharpZipLib.dll");
+                if (stream == null)
+                    return null;
+
+                using var ms = new MemoryStream();
+                stream.CopyTo(ms);
+                return Assembly.Load(ms.ToArray());
+            };
+        }
     }
 }

--- a/RagnaPH Launcher/RagnaPH Launcher.csproj
+++ b/RagnaPH Launcher/RagnaPH Launcher.csproj
@@ -165,15 +165,20 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <!-- Explicit reference to SharpZipLib to ensure availability during cross-platform builds -->
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>$(NuGetPackageRoot)sharpziplib/1.4.2/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
-      <CopyLocal>True</CopyLocal>
+      <HintPath>$(PkgSharpZipLib)/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>False</Private>
+      <CopyLocal>False</CopyLocal>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(PkgSharpZipLib)/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll">
+      <LogicalName>RagnaPH.Libs.ICSharpCode.SharpZipLib.dll</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
## Summary
- Embed SharpZipLib DLL as a resource and load it on demand
- Redirect SharpZipLib binding to version 1.4.2.13
- Reference SharpZipLib from NuGet package and remove committed binary

## Testing
- `strings /root/.nuget/packages/sharpziplib/1.4.2/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll | grep -m 1 1.4.2.13`
- `dotnet build 'RagnaPH Launcher/RagnaPH Launcher.csproj' -v minimal` *(fails: Program does not contain a static 'Main' method suitable for an entry point)*
- `dotnet test 'RagnaPH Launcher.Tests/RagnaPH Launcher.Tests.csproj' -v minimal` *(fails: Program does not contain a static 'Main' method suitable for an entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d554625c832ea2266dc4daf0b930