### PR TITLE
feat: integrate optional GRF editor support

### DIFF
--- a/RagnaPH Launcher/App.xaml.cs
+++ b/RagnaPH Launcher/App.xaml.cs
@@ -15,11 +15,23 @@ namespace RagnaPH_Launcher
             AppDomain.CurrentDomain.AssemblyResolve += (s, e) =>
             {
                 var name = new AssemblyName(e.Name).Name;
-                if (!name.Equals("ICSharpCode.SharpZipLib", StringComparison.OrdinalIgnoreCase))
+                string? resource = name switch
+                {
+                    var n when n.Equals("ICSharpCode.SharpZipLib", StringComparison.OrdinalIgnoreCase)
+                        => "RagnaPH.Libs.ICSharpCode.SharpZipLib.dll",
+                    // Optional: resolve the GRFEditor library when embedded. If
+                    // the resource is missing the normal probing rules apply
+                    // which allows the launcher to run without bundling the
+                    // dependency.
+                    var n when n.Equals("GRF", StringComparison.OrdinalIgnoreCase)
+                        => "RagnaPH.Libs.GRF.dll",
+                    _ => null
+                };
+
+                if (resource == null)
                     return null;
 
-                using var stream = Assembly.GetExecutingAssembly()
-                    .GetManifestResourceStream("RagnaPH.Libs.ICSharpCode.SharpZipLib.dll");
+                using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resource);
                 if (stream == null)
                     return null;
 

--- a/RagnaPH Launcher/Patching/RealGrfEditor.cs
+++ b/RagnaPH Launcher/Patching/RealGrfEditor.cs
@@ -1,43 +1,161 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace RagnaPH.Patching;
 
 /// <summary>
-/// Real implementation of <see cref="IGrfEditor"/> backed by the GRF Editor
-/// library. The original implementation relied on the external GRF.Core
-/// package which is not available in this environment. To keep the rest of the
-/// patching pipeline functional, this class now delegates all operations to
-/// <see cref="MockGrfEditor"/> which stores patched files on disk without
-/// touching real GRF archives.
+/// Real implementation of <see cref="IGrfEditor"/>.  When the official
+/// GRFEditor library is available it is used via reflection; otherwise a
+/// lightweight file system based fallback (<see cref="MockGrfEditor"/>) keeps
+/// the patching pipeline operational.  This allows the launcher to apply THOR
+/// patches against real GRF archives when the dependency is present while still
+/// remaining functional in trimmed test environments.
 /// </summary>
 public sealed class RealGrfEditor : IGrfEditor
 {
-    // Delegate all behaviour to the mock implementation. This allows the
-    // application to compile and run without the external GRF.Core dependency
-    // while preserving the expected behaviour for unit tests and basic
-    // patching scenarios.
-    private readonly MockGrfEditor _inner = new();
+    private readonly MockGrfEditor _fallback = new();
 
-    public Task OpenAsync(string grfPath, bool createIfMissing, CancellationToken ct)
-        => _inner.OpenAsync(grfPath, createIfMissing, ct);
+    // Reflection based accessors for the GRF library.  When _holderType is null
+    // the fallback implementation is used.
+    private readonly Assembly? _grfAssembly;
+    private readonly Type? _holderType;
+    private object? _holder;
+    private object? _commands;
 
-    public Task AddOrReplaceAsync(string virtualPath, Stream content, CancellationToken ct)
-        => _inner.AddOrReplaceAsync(virtualPath, content, ct);
+    public RealGrfEditor()
+    {
+        try
+        {
+            _grfAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name.Equals("GRF", StringComparison.OrdinalIgnoreCase));
 
-    public Task DeleteAsync(string virtualPath, CancellationToken ct)
-        => _inner.DeleteAsync(virtualPath, ct);
+            _holderType = _grfAssembly?.GetType("GRF.ContainerFormat.GrfHolder");
+        }
+        catch
+        {
+            _grfAssembly = null;
+            _holderType = null;
+        }
+    }
+
+    private bool UseFallback => _holderType is null;
+
+    public async Task OpenAsync(string grfPath, bool createIfMissing, CancellationToken ct)
+    {
+        if (UseFallback)
+        {
+            await _fallback.OpenAsync(grfPath, createIfMissing, ct);
+            return;
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        if (!File.Exists(grfPath))
+        {
+            if (createIfMissing)
+            {
+                // Create an empty placeholder; the GRF library will initialise
+                // the structure on save.
+                using (File.Create(grfPath)) { }
+            }
+            else
+            {
+                throw new FileNotFoundException(grfPath);
+            }
+        }
+
+        _holder = Activator.CreateInstance(_holderType!, new object[] { grfPath });
+        _commands = _holderType!.GetProperty("Commands")?.GetValue(_holder);
+    }
+
+    public async Task AddOrReplaceAsync(string virtualPath, Stream content, CancellationToken ct)
+    {
+        if (UseFallback || _holder is null || _commands is null)
+        {
+            await _fallback.AddOrReplaceAsync(virtualPath, content, ct);
+            return;
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        // The GRF library exposes AddFile(string,string).  To avoid relying on
+        // its internal entry types we write the stream to a temporary file and
+        // use that overload via reflection.
+        string tmp = Path.GetTempFileName();
+        try
+        {
+            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                await content.CopyToAsync(fs, 81920, ct);
+            }
+
+            var method = _commands.GetType().GetMethod("AddFile", new[] { typeof(string), typeof(string) });
+            if (method == null)
+                throw new InvalidOperationException("GRF: AddFile method not found");
+
+            method.Invoke(_commands, new object[] { virtualPath.Replace('\\', '/'), tmp });
+        }
+        finally
+        {
+            if (File.Exists(tmp))
+                File.Delete(tmp);
+        }
+    }
+
+    public async Task DeleteAsync(string virtualPath, CancellationToken ct)
+    {
+        if (UseFallback || _commands is null)
+        {
+            await _fallback.DeleteAsync(virtualPath, ct);
+            return;
+        }
+
+        ct.ThrowIfCancellationRequested();
+        var method = _commands.GetType().GetMethod("RemoveFile", new[] { typeof(string) });
+        if (method == null)
+            throw new InvalidOperationException("GRF: RemoveFile method not found");
+        method.Invoke(_commands, new object[] { virtualPath.Replace('\\', '/') });
+    }
 
     public Task RebuildIndexAsync(CancellationToken ct)
-        => _inner.RebuildIndexAsync(ct);
+    {
+        // The GRF library rebuilds its index on save; no explicit action is
+        // required.  This method exists for API symmetry.
+        return Task.CompletedTask;
+    }
 
     public Task FlushAsync(CancellationToken ct)
-        => _inner.FlushAsync(ct);
+    {
+        if (UseFallback || _holder is null)
+            return _fallback.FlushAsync(ct);
+
+        ct.ThrowIfCancellationRequested();
+        _holderType!.GetMethod("QuickSave")?.Invoke(_holder, null);
+        _holderType!.GetMethod("Reload")?.Invoke(_holder, null);
+        return Task.CompletedTask;
+    }
 
     public Task VerifyAsync(CancellationToken ct)
-        => _inner.VerifyAsync(ct);
+    {
+        if (UseFallback)
+            return _fallback.VerifyAsync(ct);
 
-    public void Dispose() => _inner.Dispose();
+        // No specific verification is required here; the GRF library performs
+        // integrity checks when loading and saving.  Keep the method for
+        // interface compliance.
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_holder is IDisposable disp)
+            disp.Dispose();
+        else
+            _fallback.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary
- allow runtime use of the official GRFEditor library with reflection fallback to existing mock implementation
- extend assembly resolver to load embedded GRF editor binaries when available

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50def6664832ea258221475385d89